### PR TITLE
Fix bug in javascript asset registration that prevented oauth redirections.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -34,5 +34,5 @@ auth_provider title:         settings.title,
               frame_width:   settings.frame_width,
               frame_height:  settings.frame_height
 
-register_asset 'doorkeeper.js'
+register_asset 'doorkeeper.js', :server_side
 register_asset 'doorkeeper.css'


### PR DESCRIPTION
Without this option, the JS never executes, preventing the doorkeeper signin from ever happening.
